### PR TITLE
Fix: base class metadata lost for API pages

### DIFF
--- a/website/pages/[...listPathPage].tsx
+++ b/website/pages/[...listPathPage].tsx
@@ -106,15 +106,18 @@ export const getStaticProps: GetStaticProps<PropsPage, ParsedUrlQuery> = async (
             : null
     const section = mdx.frontmatter.section ?? parentFolder
     const sectionMeta = section ? recordSection[section] ?? null : null
-    const baseClass = null
+
+    // Determine base class details from frontmatter, if provided
+    const baseClass = mdx.frontmatter.api_base_class
+        ? {
+              title: mdx.frontmatter.api_base_class_title ?? mdx.frontmatter.title,
+              slug: mdx.frontmatter.api_base_class,
+          }
+        : null
+
     const apiDetails: ApiDetails = {
         stringName: mdx.frontmatter.api_string_name ?? null,
-        baseClass: baseClass
-            ? {
-                  title: mdx.frontmatter.title,
-                  slug: mdx.frontmatter.api_base_class,
-              }
-            : null,
+        baseClass,
         trainable: mdx.frontmatter.api_trainable ?? null,
     }
 


### PR DESCRIPTION
## What was wrong
`apiDetails.baseClass` in [website/pages/[...listPathPage].tsx](cci:7://file:///c:/Users/T2430514/Downloads/spaCy/website/pages/%5B...listPathPage%5D.tsx:0:0-0:0) was hard-coded to `null`, ignoring the `api_base_class` and `api_base_class_title` values provided in page front-matter.  
As a result, API reference pages could not render “extends …​” information or generate correct cross-links, hurting usability and discoverability of the docs.

## How it’s fixed
The placeholder line was replaced with real logic:

```ts
const baseClass = mdx.frontmatter.api_base_class
  ? {
      title: mdx.frontmatter.api_base_class_title ?? mdx.frontmatter.title,
      slug:  mdx.frontmatter.api_base_class,
    }
  : null;
```
apiDetails.baseClass now receives this object, allowing the UI to show accurate base-class data whenever it’s supplied, while still defaulting to null when it isn’t.

